### PR TITLE
feat(roadmap): introduce roadmap management plugin with GitHub Projects integration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -138,6 +138,16 @@
       "author": {
         "name": "Linehaul AI"
       }
+    },
+    {
+      "name": "roadmap",
+      "source": "./plugins/roadmap",
+      "version": "0.2.0",
+      "description": "Project roadmap management with GitHub Projects integration",
+      "author": {
+        "name": "fakebizprez"
+      },
+      "keywords": ["roadmap", "planning", "github-projects", "project-management"]
     }
   ]
 }

--- a/plugins/roadmap/.claude-plugin/plugin.json
+++ b/plugins/roadmap/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "roadmap",
+  "version": "0.2.0",
+  "description": "Project roadmap management with GitHub Projects integration",
+  "author": {
+    "name": "fakebizprez"
+  },
+  "keywords": ["roadmap", "planning", "github-projects", "project-management"]
+}

--- a/plugins/roadmap/README.md
+++ b/plugins/roadmap/README.md
@@ -1,0 +1,76 @@
+# Roadmap Plugin
+
+Project roadmap management with GitHub Projects integration.
+
+## Overview
+
+Manage your project roadmap in a `specs/ROADMAP.toml` file and sync it with GitHub Projects. Uses a spec-driven approach where the roadmap serves as the ultimate "to-do list" for development.
+
+## Features
+
+- **TOML-based roadmap**: Simple, version-controlled roadmap format
+- **GitHub Projects sync**: Push roadmap items to GitHub Projects via `gh` CLI
+- **Pull from GitHub**: Fetch status updates from GitHub back to TOML
+- **Rich metadata**: Track type (bug/feature/task), stack layer (backend/frontend/devops), priority (P0/P1/P3), and start dates
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/roadmap:init` | Create initial `specs/ROADMAP.toml` |
+| `/roadmap:add` | Add a new item to the roadmap |
+| `/roadmap:list` | Display current roadmap status |
+| `/roadmap:sync` | Push roadmap to GitHub Projects |
+| `/roadmap:pull` | Fetch GitHub state into TOML |
+
+## Agent
+
+| Agent | Description |
+|-------|-------------|
+| `roadmap-planner` | Helps brainstorm and structure your roadmap |
+
+## TOML Format
+
+```toml
+project = "your-project-name"
+
+[[items]]
+title = "Feature Name"
+label = "feature-label"
+description = "What this feature does"
+type = "feature"          # bug | feature | task
+stack_layer = "backend"   # backend | frontend | devops
+priority = "P1"           # P0 (critical) | P1 (high) | P3 (low)
+status = "pending"        # pending | in_progress | done
+start_date = "2024-01-15" # auto-filled when using /roadmap:add
+```
+
+### Field Reference
+
+| Field | Values | Description |
+|-------|--------|-------------|
+| `type` | `bug`, `feature`, `task` | Type of work item |
+| `stack_layer` | `backend`, `frontend`, `devops` | Which part of the stack |
+| `priority` | `P0`, `P1`, `P3` | P0 = critical, P1 = high, P3 = low |
+| `status` | `pending`, `in_progress`, `done` | Current status |
+| `start_date` | `YYYY-MM-DD` | Auto-set to today when adding |
+
+## Prerequisites
+
+- `gh` CLI installed and authenticated
+- GitHub Project created (e.g., using PRODUCT LAUNCH template)
+- Project scope for gh CLI: `gh auth refresh -s read:project`
+
+## Installation
+
+From the linehaulai-claude-marketplace:
+
+```bash
+/plugin install roadmap@linehaulai-claude-marketplace
+```
+
+Or for local development:
+
+```bash
+claude --plugin-dir /path/to/plugins/roadmap
+```

--- a/plugins/roadmap/agents/roadmap-planner.md
+++ b/plugins/roadmap/agents/roadmap-planner.md
@@ -1,0 +1,120 @@
+---
+name: roadmap-planner
+description: Use this agent when the user explicitly asks for help planning, brainstorming, or structuring their project roadmap. This agent helps transform high-level goals into actionable roadmap items.
+
+<example>
+Context: User wants to plan out their project features
+user: "Help me plan my roadmap for the next quarter"
+assistant: "I'll use the roadmap-planner agent to help you structure your project roadmap."
+<commentary>
+User explicitly asked for roadmap planning help. This agent will brainstorm features, prioritize them, and help structure them into TOML format.
+</commentary>
+</example>
+
+<example>
+Context: User has a vague idea and needs to break it down
+user: "I want to add billing to my app but I'm not sure how to break it down"
+assistant: "Let me use the roadmap-planner agent to help break down the billing feature into roadmap items."
+<commentary>
+User needs help decomposing a large feature into smaller roadmap items. The agent will analyze the domain and suggest a breakdown.
+</commentary>
+</example>
+
+<example>
+Context: User wants to prioritize existing ideas
+user: "I have these 10 features in mind, help me prioritize them for the roadmap"
+assistant: "I'll use the roadmap-planner agent to analyze and prioritize these features."
+<commentary>
+User has items but needs help ordering them. The agent will consider dependencies, value, and effort to suggest priorities.
+</commentary>
+</example>
+
+model: inherit
+color: cyan
+tools:
+  - Read
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+You are a strategic product roadmap planner specializing in breaking down high-level goals into actionable, well-structured roadmap items.
+
+**Your Core Responsibilities:**
+1. Help users articulate and refine their project vision
+2. Break down large features into smaller, deliverable items
+3. Identify dependencies between items
+4. Suggest logical prioritization based on value and effort
+5. Structure items in the TOML format used by specs/ROADMAP.toml
+
+**Planning Process:**
+
+1. **Understand the Vision**
+   - Ask clarifying questions about goals and constraints
+   - Identify the target users and their needs
+   - Understand technical constraints or existing systems
+
+2. **Brainstorm Items**
+   - Generate potential features/tasks based on goals
+   - Consider MVP vs. future enhancements
+   - Think about infrastructure, features, and polish
+
+3. **Analyze Dependencies**
+   - Identify which items depend on others
+   - Note items that can be parallelized
+   - Flag potential blockers
+
+4. **Prioritize**
+   - Consider value to users
+   - Consider implementation effort
+   - Account for dependencies
+   - Suggest priority numbers (1 = highest)
+
+5. **Structure Output**
+   - Format items for TOML compatibility
+   - Include title, label, description, priority
+   - Default status to "pending"
+
+**Output Format:**
+
+Present roadmap items in this structure:
+
+```
+## Suggested Roadmap Items
+
+### Priority 1 (Critical Path)
+1. **[Title]** (`label`)
+   - Description: [What this accomplishes]
+   - Dependencies: [None / List of labels]
+
+### Priority 2 (Important)
+...
+
+### Priority 3 (Nice to Have)
+...
+```
+
+Then provide TOML-ready format:
+
+```toml
+[[items]]
+title = "..."
+label = "..."
+description = "..."
+status = "pending"
+priority = 1
+```
+
+**Guidelines:**
+- Keep titles concise but descriptive (3-7 words)
+- Labels should be kebab-case, unique, 2-3 words max
+- Descriptions should explain the "what" and "why" in 1-2 sentences
+- Group related items under logical themes
+- Consider suggesting phases/milestones for large roadmaps
+
+**Integration Note:**
+After planning, users can:
+- Copy items directly to `specs/ROADMAP.toml`
+- Use `/roadmap:add` to add items interactively
+- Use `/roadmap:sync` to push to GitHub Projects
+- Run `/sdd:01-specify` on individual items for detailed specs (if SDD plugin is installed)

--- a/plugins/roadmap/commands/add.md
+++ b/plugins/roadmap/commands/add.md
@@ -1,0 +1,53 @@
+---
+name: add
+description: Add a new item to the roadmap interactively
+allowed-tools:
+  - Read
+  - Edit
+  - AskUserQuestion
+---
+
+# Add Roadmap Item
+
+Interactively add a new item to `specs/ROADMAP.toml`.
+
+## Steps
+
+1. Read `specs/ROADMAP.toml` to understand current items
+   - If file doesn't exist, suggest running `/roadmap:init` first
+
+2. Ask the user for item details using AskUserQuestion:
+   - **Title**: What is this feature/task called?
+   - **Label**: Short identifier (kebab-case, e.g., "user-auth", "billing-v2")
+   - **Description**: Brief description of what this accomplishes
+   - **Type**: bug | feature | task
+   - **Stack Layer**: backend | frontend | devops
+   - **Priority**: P0 (critical) | P1 (high) | P3 (low)
+   - **Status**: Default to "pending" unless specified
+
+3. Auto-generate today's date for `start_date` using the current date (YYYY-MM-DD format)
+
+4. Append the new item to the TOML file:
+
+```toml
+[[items]]
+title = "User provided title"
+label = "user-provided-label"
+description = "User provided description"
+type = "feature"
+stack_layer = "backend"
+priority = "P1"
+status = "pending"
+start_date = "2024-01-15"
+```
+
+5. Confirm the item was added and show the updated item count
+
+## Notes
+
+- Labels should be unique and kebab-case
+- `start_date` is always auto-filled with today's date (YYYY-MM-DD)
+- Valid types: `bug`, `feature`, `task`
+- Valid stack layers: `backend`, `frontend`, `devops`
+- Valid priorities: `P0` (critical), `P1` (high), `P3` (low)
+- Keep descriptions concise but meaningful

--- a/plugins/roadmap/commands/init.md
+++ b/plugins/roadmap/commands/init.md
@@ -1,0 +1,45 @@
+---
+name: init
+description: Create initial specs/ROADMAP.toml with template structure
+allowed-tools:
+  - Write
+  - Read
+  - Bash
+---
+
+# Initialize Roadmap
+
+Create a new `specs/ROADMAP.toml` file with the standard template structure.
+
+## Steps
+
+1. Check if `specs/ROADMAP.toml` already exists
+   - If it exists, ask the user if they want to overwrite it
+   - If they decline, exit gracefully
+
+2. Create the `specs/` directory if it doesn't exist
+
+3. Create `specs/ROADMAP.toml` with this template:
+
+```toml
+# Project Roadmap
+# Managed by roadmap plugin - sync with GitHub Projects via /roadmap:sync
+
+project = "laneweaverTMS_launch"
+
+# Example item (remove or modify):
+[[items]]
+title = "Example Feature"
+label = "example"
+description = "Replace this with your first roadmap item"
+type = "feature"          # bug | feature | task
+stack_layer = "backend"   # backend | frontend | devops
+priority = "P1"           # P0 | P1 | P3
+status = "pending"        # pending | in_progress | done
+start_date = "2024-01-15" # auto-filled when adding items
+```
+
+4. Confirm creation to the user and suggest next steps:
+   - Edit the file to add real items
+   - Use `/roadmap:add` to add items interactively
+   - Use `/roadmap:sync` to push to GitHub Projects

--- a/plugins/roadmap/commands/list.md
+++ b/plugins/roadmap/commands/list.md
@@ -1,0 +1,47 @@
+---
+name: list
+description: Display current roadmap status in a formatted table
+allowed-tools:
+  - Read
+---
+
+# List Roadmap
+
+Display the current roadmap from `specs/ROADMAP.toml` in a readable format.
+
+## Steps
+
+1. Read `specs/ROADMAP.toml`
+   - If file doesn't exist, inform user and suggest `/roadmap:init`
+
+2. Parse the TOML content and extract:
+   - Project name
+   - All items with their fields
+
+3. Display in a formatted table, grouped by status:
+
+```
+📋 Roadmap: laneweaverTMS_launch
+
+🔴 Pending (3 items)
+┌────┬─────────────────────┬──────────┬──────────┬──────────┬────────────┬─────────────────────────────┐
+│ P  │ Title               │ Type     │ Layer    │ Label    │ Started    │ Description                 │
+├────┼─────────────────────┼──────────┼──────────┼──────────┼────────────┼─────────────────────────────┤
+│ P0 │ User Authentication │ feature  │ backend  │ auth     │ 2024-01-15 │ OAuth login with providers  │
+│ P1 │ Carrier Onboarding  │ feature  │ backend  │ carrier  │ 2024-01-16 │ MCP integration for...      │
+│ P3 │ UI Polish           │ task     │ frontend │ ui-fix   │ 2024-01-17 │ Minor styling adjustments   │
+└────┴─────────────────────┴──────────┴──────────┴──────────┴────────────┴─────────────────────────────┘
+
+🟡 In Progress (1 item)
+...
+
+🟢 Done (2 items)
+...
+
+Summary: 3 pending, 1 in progress, 2 done (6 total)
+By Layer: 2 backend, 1 frontend, 0 devops
+By Type: 2 features, 0 bugs, 1 task
+```
+
+4. If items exist, mention sync status:
+   - "Run `/roadmap:sync` to push changes to GitHub Projects"

--- a/plugins/roadmap/commands/pull.md
+++ b/plugins/roadmap/commands/pull.md
@@ -1,0 +1,69 @@
+---
+name: pull
+description: Fetch GitHub Project state and update ROADMAP.toml
+allowed-tools:
+  - Read
+  - Edit
+  - Bash
+  - AskUserQuestion
+---
+
+# Pull from GitHub Projects
+
+Fetch the current state from GitHub Projects and update `specs/ROADMAP.toml`.
+
+## Prerequisites
+
+- `gh` CLI installed and authenticated
+- GitHub Project exists with items synced via `/roadmap:sync`
+
+## Steps
+
+1. Read `specs/ROADMAP.toml` to get:
+   - Project name
+   - Current items (for matching)
+
+2. Fetch project items from GitHub:
+   ```bash
+   gh project item-list <PROJECT_NUMBER> --owner @me --format json
+   ```
+
+3. For each item in GitHub Project:
+
+   a. Match to TOML item by title or label
+
+   b. Get current status from project column:
+      - "Todo" → `status = "pending"`
+      - "In Progress" → `status = "in_progress"`
+      - "Done" → `status = "done"`
+
+   c. If item exists in TOML but status differs:
+      - Update the status in TOML
+
+   d. If item exists in GitHub but not in TOML:
+      - Ask user: "Found new item in GitHub: '<title>'. Add to TOML?"
+      - If yes, append to TOML with defaults:
+        - `type = "task"`
+        - `stack_layer = "backend"`
+        - `priority = "P3"`
+        - `start_date` = today's date
+
+   e. If item exists in TOML but not in GitHub:
+      - Warn user: "Item '<title>' not found in GitHub. Keep in TOML?"
+
+4. Write updated TOML preserving formatting
+
+5. Report changes:
+   - Items updated (status changes)
+   - Items added from GitHub
+   - Items only in TOML (warnings)
+
+## Notes
+
+- TOML remains source of truth for descriptions, types, layers, and priorities
+- Only status is pulled from GitHub by default
+- New items from GitHub get defaults:
+  - `type = "task"`
+  - `stack_layer = "backend"`
+  - `priority = "P3"` (lowest)
+  - `start_date` = current date

--- a/plugins/roadmap/commands/sync.md
+++ b/plugins/roadmap/commands/sync.md
@@ -1,0 +1,79 @@
+---
+name: sync
+description: Push roadmap items to GitHub Projects via gh CLI
+allowed-tools:
+  - Read
+  - Bash
+  - AskUserQuestion
+---
+
+# Sync Roadmap to GitHub
+
+Push `specs/ROADMAP.toml` items to GitHub Projects using the `gh` CLI.
+
+## Prerequisites
+
+- `gh` CLI installed and authenticated
+- GitHub Project exists (specified in TOML `project` field)
+
+## Steps
+
+1. Read `specs/ROADMAP.toml` and parse items
+   - If file doesn't exist, suggest `/roadmap:init`
+
+2. Get the project name from TOML header (`project = "..."`)
+   - If not set, ask user for project name
+
+3. Verify `gh` CLI is available:
+   ```bash
+   gh --version
+   ```
+
+4. Get the GitHub Project ID:
+   ```bash
+   gh project list --owner @me --format json
+   ```
+   - Find the project matching the name
+   - If not found, inform user and exit
+
+5. For each item in the roadmap:
+
+   a. Check if item already exists in project (by title):
+   ```bash
+   gh project item-list <PROJECT_NUMBER> --owner @me --format json
+   ```
+
+   b. If item exists, update it:
+   ```bash
+   gh project item-edit --project-id <PROJECT_ID> --id <ITEM_ID> --field-id <STATUS_FIELD_ID> --single-select-option-id <STATUS_OPTION_ID>
+   ```
+
+   c. If item doesn't exist, create it as a draft issue:
+   ```bash
+   gh project item-create <PROJECT_NUMBER> --owner @me --title "<TITLE>" --body "<DESCRIPTION>"
+   ```
+
+6. Map status values:
+   - `pending` → Project "Todo" column
+   - `in_progress` → Project "In Progress" column
+   - `done` → Project "Done" column
+
+7. Map custom fields if the project has them configured:
+   - `type` → "Type" field (Bug, Feature, Task)
+   - `stack_layer` → "Stack Layer" field (Backend, Frontend, Devops)
+   - `priority` → "Priority" field (P0, P1, P3)
+   - `start_date` → "Start Date" field
+
+8. Report sync results:
+   - Items created
+   - Items updated
+   - Any errors encountered
+
+## Notes
+
+- Uses draft issues (not repo issues) for roadmap items
+- If custom fields don't exist in GitHub Project, include them in the item body:
+  ```
+  **Type:** feature | **Layer:** backend | **Priority:** P1 | **Started:** 2024-01-15
+  ```
+- Label is used to identify items for updates


### PR DESCRIPTION
This commit adds a new roadmap management plugin that allows users to manage project roadmaps using a TOML format and synchronize with GitHub Projects. Key features include interactive item addition, status synchronization, and a dedicated agent for planning and structuring roadmaps.

Changes:
- Added `roadmap` plugin with commands for initializing, adding, listing, syncing, and pulling roadmap items
- Created README and documentation for the plugin's functionality and usage
- Implemented a `roadmap-planner` agent to assist users in planning and prioritizing roadmap items
- Updated marketplace.json to include the new plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Roadmap plugin for project planning with GitHub Projects integration
  * New roadmap management commands: init, add, list, sync, and pull
  * TOML-based roadmap file format with bidirectional GitHub Projects synchronization
  * Includes roadmap-planner agent for structured project planning

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->